### PR TITLE
[feat] react-modal - modal-ctrl

### DIFF
--- a/apps/playground-react/src/App.tsx
+++ b/apps/playground-react/src/App.tsx
@@ -93,6 +93,14 @@ function App() {
         >
           알림
         </button>
+
+        <button
+          onClick={() => {
+            modalCtrl.alert("잘되나?후...");
+          }}
+        >
+          알림2
+        </button>
         <DynamicModal options={{ duration: 1500, position: "center" }}>
           <DynamicModal.Trigger>다이나믹 모달</DynamicModal.Trigger>
           <DynamicModal.Element>

--- a/apps/playground-react/src/modal.tsx
+++ b/apps/playground-react/src/modal.tsx
@@ -6,6 +6,7 @@ export const { modalCtrl, DynamicModal, ModalProvider } = generateModal(
       component: ({ payload }) => (
         <div className="w-[200px] h-[200px] bg-white">
           안녕하세요 {payload}
+          <Modal.Content />
           <div>
             <Modal.Action.Confirm>반가워요</Modal.Action.Confirm>
             <Modal.Action.Cancel>취소</Modal.Action.Cancel>

--- a/packages/modal/.eslintrc.js
+++ b/packages/modal/.eslintrc.js
@@ -64,27 +64,6 @@ module.exports = {
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/array-type": ["error", { default: "array" }],
     "@typescript-eslint/no-unused-vars": "warn",
-    "@typescript-eslint/member-ordering": [
-      "warn",
-      {
-        default: [
-          "public-static-field",
-          "protected-static-field",
-          "private-static-field",
-          "public-instance-field",
-          "protected-instance-field",
-          "private-instance-field",
-          "constructor",
-          "public-static-method",
-          "protected-static-method",
-          "private-static-method",
-          "public-instance-method",
-          "protected-instance-method",
-          "private-instance-method",
-        ],
-      },
-    ],
-
     "import/order": [
       "error",
       {
@@ -110,7 +89,7 @@ module.exports = {
     "prettier/prettier": [
       "error",
       {
-        endOfLine: "auto",
+        endOfLine: "flow",
       },
     ],
   },

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junhee_h/react-modal",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "리액트 모달을 쉽게 등록하고 사용가능한 라이브러리입니다.",
   "scripts": {
     "build": "rollup -c --bundleConfigAsCjs",

--- a/packages/modal/readme.md
+++ b/packages/modal/readme.md
@@ -236,11 +236,11 @@ function App() {
 import { ModalFC } from "@junhee_h/react-modal";
 
 const ExampleModal: ModalFC = ({
-	title,
-	content,
-	confirmContent,
-	cancelContent,
-	action
+  title,
+  content,
+  confirmContent,
+  cancelContent,
+  action
 }) => {
   return (
     <div>
@@ -468,7 +468,7 @@ function Example() {
 import { generateModal } from "@junhee_h/react-modal";
 
 export const { modalCtrl } = generatorModal({
-	...modalComponentTable
+  ...modalComponentTable
 }, {
   position: {
     // 사용자에 맞춘 커스텀 position을 만들 수 있습니다.

--- a/packages/modal/src/contants/index.ts
+++ b/packages/modal/src/contants/index.ts
@@ -47,7 +47,7 @@ export const RESERVED_MODAL_NAME: {
   close: "close",
   edit: "edit",
   remove: "remove",
-  action: "action"
+  action: "action",
 };
 
 export const DEFAULT_DURATION = 300;

--- a/packages/modal/src/generate.ts
+++ b/packages/modal/src/generate.ts
@@ -34,13 +34,20 @@ function generateModalController<
       const modalName = modalEntry[0] as Extract<keyof T, string>;
 
       controller[modalName] = (
-        options:
+        options?:
           | (T[typeof modalName]["defaultOptions"] extends {
             payload: infer R;
           }
-            ? Omit<ModalDispatchOptions<R, Extract<keyof P, string>>, "required">
-            : Omit<ModalDispatchOptions<any, Extract<keyof P, string>>, "required">)
+            ? Omit<
+              ModalDispatchOptions<R, Extract<keyof P, string>>,
+              "required"
+            >
+            : Omit<
+              ModalDispatchOptions<any, Extract<keyof P, string>>,
+              "required"
+            >)
           | ModalCallback
+          | string
       ) => modalManager.open(modalName, options);
 
       return controller;
@@ -104,7 +111,9 @@ export function generateModal<
     string,
     Extract<keyof ExtractPositionType<P>, string>
   >,
-  P extends ModalManagerOptionsProps = ModalManagerOptionsProps<ModalPositionTable<DefaultModalPosition>>
+  P extends ModalManagerOptionsProps = ModalManagerOptionsProps<
+    ModalPositionTable<DefaultModalPosition>
+  >
 >(modalComponentSeedTable: T = {} as T, options: P = {} as P) {
   const modalComponentSeedEntries = Object.entries(modalComponentSeedTable);
   const modalComponentSeedList = modalComponentSeedEntries.map(

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -3,7 +3,7 @@ export type {
   ModalComponentSeed,
   ModalComponent as ModalFC,
   ModalConfirmType,
-  ModalCallback
+  ModalCallback,
 } from "./types";
 
 export { Modal } from "./components";

--- a/packages/modal/src/services/modal.ts
+++ b/packages/modal/src/services/modal.ts
@@ -33,8 +33,8 @@ interface ModalProps {
 export class Modal {
   private lifecycleState: ModalLifecycleState = MODAL_LIFECYCLE_STATE.open;
   private actionState: ModalActionState = MODAL_ACTION_STATE.initial;
-  private actionCallback: ModalCallback = () => { };
-  private afterCloseCallback: () => unknown = () => { };
+  private actionCallback: ModalCallback = () => {};
+  private afterCloseCallback: () => unknown = () => {};
   private listeners: ((state: ModalState) => void)[] = [];
   private breakPoint = 0;
   private isInitial = false;
@@ -86,7 +86,13 @@ export class Modal {
   }
 
   private setOption() {
-    const { closeDelay, action, stateResponsiveComponent, escKeyActive, enterKeyActive } = this.options;
+    const {
+      closeDelay,
+      action,
+      stateResponsiveComponent,
+      escKeyActive,
+      enterKeyActive,
+    } = this.options;
 
     if (closeDelay) {
       this._closeDelayDuration = closeDelay;
@@ -159,7 +165,12 @@ export class Modal {
 
   /* 컴포넌트 및 상태 관리 */
 
-  private setComponentProps(options: Omit<Partial<ModalComponentProps>, "action" | "actionState" | "payload"> = {}) {
+  private setComponentProps(
+    options: Omit<
+      Partial<ModalComponentProps>,
+      "action" | "actionState" | "payload"
+    > = {}
+  ) {
     const {
       title,
       subTitle,
@@ -351,7 +362,7 @@ export class Modal {
       modalStyle: this.getModalStyle(),
       backCoverStyle: this.getBackCoverStyle(),
       isEscKeyActive: this.escKeyActive,
-      isEnterKeyActive: this.enterKeyActive
+      isEnterKeyActive: this.enterKeyActive,
     };
   }
 

--- a/packages/modal/src/services/modalManager.ts
+++ b/packages/modal/src/services/modalManager.ts
@@ -1,3 +1,4 @@
+import { isValidElement, ReactElement } from "react";
 import {
   DEFAULT_DURATION,
   DEFAULT_POSITION,
@@ -33,12 +34,10 @@ import { defaultMiddleware } from "../utils/defaultMiddleware";
 import { getCloseModal } from "../utils/getCloseModal";
 import { getPositionKey } from "../utils/getPositionKey";
 import { Modal } from "./modal";
-import { isValidElement, ReactElement } from "react";
 
-class ModalManager<T extends ModalPositionTable = ModalPositionTable>
-  implements ModalManagerInterface {
-  private currentId: number = 0;
-  private transactionCount: number = 0;
+class ModalManager<T extends ModalPositionTable = ModalPositionTable> implements ModalManagerInterface {
+  private currentId = 0;
+  private transactionCount = 0;
   private transactionState: ModalTransactionState =
     MODAL_TRANSACTION_STATE.idle;
   private modalStack: Modal[] = [];
@@ -47,8 +46,8 @@ class ModalManager<T extends ModalPositionTable = ModalPositionTable>
   private modalPositionMap: ModalPositionMap = new Map();
   private modalTransition: ModalTransition = DEFAULT_TRANSITION;
   private modalDuration: number = DEFAULT_DURATION;
-  private stateResponsiveComponent: boolean = false;
-  private breakPoint: number = 0;
+  private stateResponsiveComponent = false;
+  private breakPoint = 0;
   private modalManagerState!: ModalManagerState;
 
   constructor(
@@ -105,7 +104,7 @@ class ModalManager<T extends ModalPositionTable = ModalPositionTable>
       transactionState: this.transactionState,
       isOpen: this.modalStack.length > 0 ? true : false,
       breakPoint: this.breakPoint,
-      currentModalId: this.getCurrentModalId()
+      currentModalId: this.getCurrentModalId(),
     };
   }
 
@@ -114,7 +113,10 @@ class ModalManager<T extends ModalPositionTable = ModalPositionTable>
   private setModalComponentSeedMap(componentSeed: ModalComponentSeed) {
     const { name, component, defaultOptions } = componentSeed;
 
-    if (component === undefined || Object.prototype.hasOwnProperty.call(RESERVED_MODAL_NAME, name)) {
+    if (
+      component === undefined ||
+      Object.prototype.hasOwnProperty.call(RESERVED_MODAL_NAME, name)
+    ) {
       return;
     }
 
@@ -293,7 +295,7 @@ class ModalManager<T extends ModalPositionTable = ModalPositionTable>
     return this;
   }
 
-  setModalDuration(duration: number = -1) {
+  setModalDuration(duration = -1) {
     if (duration < 0) {
       return this;
     }
@@ -333,7 +335,7 @@ class ModalManager<T extends ModalPositionTable = ModalPositionTable>
   }
 
   getModalTransition(
-    duration: number = -1,
+    duration = -1,
     options: ModalTransitionOptions = {}
   ): ModalTransition {
     if (duration < 0) {
@@ -551,9 +553,21 @@ class ModalManager<T extends ModalPositionTable = ModalPositionTable>
     name: string | ModalComponent | ReactElement,
     action:
       | Omit<ModalDispatchOptions<P, Extract<keyof T, string>>, "required">
-      | ModalCallback = {}
+      | ModalCallback
+      | string = {}
   ) {
-    const options = typeof action === "function" ? { action } : action;
+    const options = (() => {
+      if (typeof action === "function") {
+        return { action };
+      }
+
+      if (typeof action === "string") {
+        return { content: action };
+      }
+
+      return action;
+    })();
+
     const modalKey = options.modalKey || null;
 
     if (modalKey) {

--- a/packages/modal/src/types/commonTypes.ts
+++ b/packages/modal/src/types/commonTypes.ts
@@ -11,7 +11,6 @@ export type ModalTransitionProps = {
   [key in keyof ModalTransition]?: ModalTransition[key];
 };
 
-
 export type DefaultModalPosition =
   | "default"
   | "bottom"
@@ -25,8 +24,8 @@ export type DefaultModalPosition =
   | "rightBottom";
 
 export type DefaultModalPositionAddBackCover =
-  | "backCover" | DefaultModalPosition;
-
+  | "backCover"
+  | DefaultModalPosition;
 
 export interface PositionStyle {
   left?: string;

--- a/packages/modal/src/types/modalInterfaces.ts
+++ b/packages/modal/src/types/modalInterfaces.ts
@@ -36,11 +36,24 @@ export type Controller<
   P extends ModalPositionTable
 > = {
     [K in keyof T]: (
-      options:
+      options?:
         | (T[K]["defaultOptions"] extends { payload: infer R }
-          ? Omit<ModalDispatchOptions<R, Exclude<Extract<keyof P, string>, "backCover" | "default">>, "required">
-          : Omit<ModalDispatchOptions<any, Exclude<Extract<keyof P, string>, "backCover" | "default">>, "required">)
+          ? Omit<
+            ModalDispatchOptions<
+              R,
+              Exclude<Extract<keyof P, string>, "backCover" | "default">
+            >,
+            "required"
+          >
+          : Omit<
+            ModalDispatchOptions<
+              any,
+              Exclude<Extract<keyof P, string>, "backCover" | "default">
+            >,
+            "required"
+          >)
         | ModalCallback
+        | string
     ) => number;
   };
 
@@ -50,7 +63,16 @@ export type ModalController<
 > = {
   open: <K = any>(
     name: string | ModalComponent | ReactElement,
-    options?: Omit<ModalDispatchOptions<K, Exclude<Extract<keyof P, string>, "backCover" | "default">>, "required"> | ModalCallback
+    options?:
+      | Omit<
+        ModalDispatchOptions<
+          K,
+          Exclude<Extract<keyof P, string>, "backCover" | "default">
+        >,
+        "required"
+      >
+      | ModalCallback
+      | string
   ) => number;
   remove: (removedName?: CloseModalProps) => number;
   action: (targetModalId: number, confirm?: boolean | string) => void;

--- a/packages/modal/src/types/modalManagerTypes.ts
+++ b/packages/modal/src/types/modalManagerTypes.ts
@@ -25,8 +25,7 @@ export type ReservedModalName =
   | "close"
   | "edit"
   | "remove"
-  | "action"
-  ;
+  | "action";
 
 export type ModalRemovedName = ReservedModalName | string | string[];
 

--- a/packages/modal/src/types/modalSeedTypes.ts
+++ b/packages/modal/src/types/modalSeedTypes.ts
@@ -23,8 +23,11 @@ export interface ModalSeed<T extends ModalDispatchOptions = ModalOptions> {
 export type ModalMeta<T, P extends string = DefaultModalPosition> = {
   component: ModalComponent<T>;
   defaultOptions?: ModalDispatchOptions<T, P>;
-}
+};
 
-export type ModalComponentSeedTable<T extends string = string, P extends string = string> = {
+export type ModalComponentSeedTable<
+  T extends string = string,
+  P extends string = string
+> = {
   [name in T]: ModalMeta<any, P>;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,10 +283,10 @@ importers:
         specifier: 29.4.2
         version: 29.4.2
       react:
-        specifier: '18'
+        specifier: ^18
         version: 18.2.0
       react-dom:
-        specifier: '18'
+        specifier: ^18
         version: 18.2.0(react@18.2.0)
       rollup:
         specifier: 3.15.0


### PR DESCRIPTION
* [fix] 관심사별 클래스 메소드 분리를 위한 lint 수정

* [feat] modalCtrl feature add

- modal open시 간단한 메세지만 전달할 수 있도록 string 타입 추가